### PR TITLE
Add import 'HttpClientModule' to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ yarn add ngx-airtable
 ```
 
 ## Usage
-#### Import `NgxAirtableModule`
+#### Import `NgxAirtableModule` and `HttpClientModule`
 ```ts
 import {NgModule} from '@angular/core';
 import {NgxAirtableModule} from 'ngx-airtable';
+import {HttpClientModule} from '@angular/common/http';
 
 @NgModule({
   imports: [
+    HttpClientModule,
     NgxAirtableModule.forRoot()
   ],
   bootstrap: [AppComponent]


### PR DESCRIPTION
Using the library as-is results in a console error saying it can't find any HTTP client. Importing `HttpClientModule` into your app module solves this problem, but it's not specified anywhere in the README.